### PR TITLE
template ports.conf

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,16 @@
     update_cache: yes
     cache_valid_time: 1800
 
+- name: copy ports configuration
+  become: True
+  template:
+    src: "ports.conf.j2"
+    dest: "/etc/apache2/ports.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify: reload apache
+
 - name: copy base configuration
   become: True
   template:

--- a/templates/ports.conf.j2
+++ b/templates/ports.conf.j2
@@ -1,0 +1,17 @@
+# {{ ansible_managed }}
+
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen {{ apache_listen_port }}
+
+<IfModule ssl_module>
+	Listen {{ apache_listen_port_ssl }}
+</IfModule>
+
+<IfModule mod_gnutls.c>
+	Listen {{ apache_listen_port_ssl }}
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
The role already has `apache_listen_port` and `apache_listen_port_ssl` to configure vhosts, but without changing ports.conf, apache will still listen to 80 and 443, even if the variables are set to different values.